### PR TITLE
Replace Twig global namespaces to support Twig 3

### DIFF
--- a/Twig/FeatureExtension.php
+++ b/Twig/FeatureExtension.php
@@ -3,8 +3,10 @@
 namespace DZunke\FeatureFlagsBundle\Twig;
 
 use DZunke\FeatureFlagsBundle\Toggle;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class FeatureExtension extends \Twig_Extension
+class FeatureExtension extends AbstractExtension
 {
 
     /**
@@ -23,7 +25,7 @@ class FeatureExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('has_feature', [$this, 'checkFeature'], ['is_safe' => ['html']]),
+            new TwigFunction('has_feature', [$this, 'checkFeature'], ['is_safe' => ['html']]),
         ];
     }
 


### PR DESCRIPTION
Use of the globally namespaced Twig functions was deprecated in Twig 2.x and removed in Twig 3.x.

This commit simply replaces the globally namespaced functions with their namespaced equivalents.